### PR TITLE
Updated fluidsynth/patches to latest repo (2.2.1), added passthrough synth option

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,5 +12,5 @@
 	ignore = dirty
 [submodule "external/fluidsynth"]
 	path = external/fluidsynth
-	url = git@github.com:FluidSynth/fluidsynth.git
+	url = https://github.com/FluidSynth/fluidsynth.git
 	ignore = dirty

--- a/Config.mk
+++ b/Config.mk
@@ -7,7 +7,7 @@ ARM_HOME?=$(HOME)/gcc-arm-10.2-2020.11-x86_64-arm-none-eabi
 AARCH64_HOME?=$(HOME)/gcc-arm-10.2-2020.11-x86_64-aarch64-none-elf
 
 # Valid options: pi0, pi2, pi3, pi4, pi4-64
-BOARD?=pi4
+BOARD?=pi3
 HDMI_CONSOLE?=0
 
 # Serial bootloader config

--- a/Kernel.mk
+++ b/Kernel.mk
@@ -26,6 +26,7 @@ OBJS		:=	src/config.o \
 				src/soundfontmanager.o \
 				src/synth/mt32synth.o \
 				src/synth/soundfontsynth.o \
+				src/synth/passthroughsynth.o \
 				src/zoneallocator.o
 
 EXTRACLEAN	+=	src/*.d src/*.o \

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ $(MT32EMUBUILDDIR)/.done: $(CIRCLESTDLIBHOME)/.done
 fluidsynth: $(FLUIDSYNTHBUILDDIR)/.done
 
 $(FLUIDSYNTHBUILDDIR)/.done: $(CIRCLESTDLIBHOME)/.done
-	@patch -N -p1 --no-backup-if-mismatch -r - -d $(FLUIDSYNTHHOME) < patches/fluidsynth-2.1.8-circle.patch
+	@patch -N -p1 --no-backup-if-mismatch -r - -d $(FLUIDSYNTHHOME) < patches/fluidsynth-2.2.1-circle.patch
 
 	@export CFLAGS="$(CFLAGS_FOR_TARGET)"
 	@cmake  -B $(FLUIDSYNTHBUILDDIR) \
@@ -121,7 +121,7 @@ veryclean: clean
 	@patch -R -N -p1 --no-backup-if-mismatch -r - -d $(CIRCLEHOME) < patches/circle-43.3-usb-fix-hard-errors.patch
 	@patch -R -N -p1 --no-backup-if-mismatch -r - -d $(CIRCLEHOME) < patches/circle-43.3-pi4-usb-fix.patch
 	@patch -R -N -p1 --no-backup-if-mismatch -r - -d $(CIRCLEHOME) < patches/circle-43.3-minimal-usb-drivers.patch
-	@patch -R -N -p1 --no-backup-if-mismatch -r - -d $(FLUIDSYNTHHOME) < patches/fluidsynth-2.1.8-circle.patch
+	@patch -R -N -p1 --no-backup-if-mismatch -r - -d $(FLUIDSYNTHHOME) < patches/fluidsynth-2.2.1-circle.patch
 
 	# Clean circle-stdlib
 	@$(MAKE) -C $(CIRCLESTDLIBHOME) mrproper

--- a/include/config.h
+++ b/include/config.h
@@ -35,7 +35,7 @@ public:
 	#define ENUM_SYSTEMDEFAULTSYNTH(ENUM) \
 		ENUM(MT32, mt32)                  \
 		ENUM(SoundFont, soundfont)    \
-                ENUM(Passthrough, passthrough)
+		ENUM(Passthrough, passthrough)
 
 	#define ENUM_AUDIOOUTPUTDEVICE(ENUM) \
 		ENUM(PWM, pwm)                   \

--- a/include/config.h
+++ b/include/config.h
@@ -34,7 +34,8 @@ class CConfig
 public:
 	#define ENUM_SYSTEMDEFAULTSYNTH(ENUM) \
 		ENUM(MT32, mt32)                  \
-		ENUM(SoundFont, soundfont)
+		ENUM(SoundFont, soundfont)    \
+                ENUM(Passthrough, passthrough)
 
 	#define ENUM_AUDIOOUTPUTDEVICE(ENUM) \
 		ENUM(PWM, pwm)                   \

--- a/include/mt32pi.h
+++ b/include/mt32pi.h
@@ -53,6 +53,7 @@
 #include "synth/mt32romset.h"
 #include "synth/mt32synth.h"
 #include "synth/soundfontsynth.h"
+#include "synth/passthroughsynth.h"
 #include "synth/synth.h"
 
 class CMT32Pi : public CMultiCoreSupport, CPower, CMIDIParser
@@ -92,6 +93,7 @@ private:
 	// Initialization
 	bool InitMT32Synth();
 	bool InitSoundFontSynth();
+	bool InitPassthroughSynth();
 
 	// Tasks for specific CPU cores
 	void MainTask();
@@ -144,6 +146,9 @@ private:
 	size_t m_nDeferredSoundFontSwitchIndex;
 	unsigned m_nDeferredSoundFontSwitchTime;
 
+        //Pass through flag
+        bool m_bMIDIGPIOThru;
+
 	// Serial GPIO MIDI
 	bool m_bSerialMIDIAvailable;
 	bool m_bSerialMIDIEnabled;
@@ -171,6 +176,7 @@ private:
 	CSynthBase* m_pCurrentSynth;
 	CMT32Synth* m_pMT32Synth;
 	CSoundFontSynth* m_pSoundFontSynth;
+	CPassthroughSynth* m_pPassthroughSynth;
 
 	// MIDI receive buffer
 	CRingBuffer<u8, MIDIRxBufferSize> m_MIDIRxBuffer;

--- a/include/synth/gmsysex.h
+++ b/include/synth/gmsysex.h
@@ -29,7 +29,6 @@ enum class TGMSubID : u8
 {
 	GeneralMIDIOn  = 0x01,
 	GeneralMIDIOff = 0x02,
-        Passthrough    = 0x03,
 };
 
 struct TGMModeOnSysExMessage

--- a/include/synth/gmsysex.h
+++ b/include/synth/gmsysex.h
@@ -29,6 +29,7 @@ enum class TGMSubID : u8
 {
 	GeneralMIDIOn  = 0x01,
 	GeneralMIDIOff = 0x02,
+        Passthrough    = 0x03,
 };
 
 struct TGMModeOnSysExMessage

--- a/include/synth/passthroughsynth.h
+++ b/include/synth/passthroughsynth.h
@@ -1,0 +1,68 @@
+//
+// passthroughsynth.h
+//
+// mt32-pi - A baremetal MIDI synthesizer for Raspberry Pi
+// Copyright (C) 2020-2021 Dale Whinham <daleyo@gmail.com>
+//
+// This file is part of mt32-pi.
+//
+// mt32-pi is free software: you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// mt32-pi is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// mt32-pi. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef _passthroughsynth_h
+#define _passthroughsynth_h
+
+#include <circle/types.h>
+
+
+class CPassthroughSynth : public CSynthBase
+{
+public:
+	CPassthroughSynth(unsigned nSampleRate, float nGain = 0.2f, u32 nPolyphony = 256);
+	virtual ~CPassthroughSynth() override;
+
+	// CSynthBase
+	virtual bool Initialize() override;
+	virtual void HandleMIDIShortMessage(u32 nMessage) override;
+	virtual void HandleMIDISysExMessage(const u8* pData, size_t nSize) override;
+	virtual bool IsActive() override;
+	virtual void AllSoundOff() override;
+	virtual void SetMasterVolume(u8 nVolume) override;
+	virtual size_t Render(s16* pOutBuffer, size_t nFrames) override;
+	virtual size_t Render(float* pOutBuffer, size_t nFrames) override;
+	virtual u8 GetChannelVelocities(u8* pOutVelocities, size_t nMaxChannels) override;
+	virtual void ReportStatus() const override;
+
+	bool SwitchSoundFont(size_t nIndex);
+	size_t GetSoundFontIndex() const { return m_nCurrentSoundFontIndex; }
+	CSoundFontManager& GetSoundFontManager() { return m_SoundFontManager; }
+
+private:
+	bool Reinitialize(const char* pSoundFontPath);
+
+	fluid_settings_t* m_pSettings;
+	fluid_synth_t* m_pSynth;
+
+	float m_nInitialGain;
+	float m_nCurrentGain;
+
+	u32 m_nPolyphony;
+	size_t m_nCurrentSoundFontIndex;
+
+	CSoundFontManager m_SoundFontManager;
+
+	static void FluidSynthLogCallback(int nLevel, const char* pMessage, void* pUser);
+};
+
+#endif

--- a/include/synth/synth.h
+++ b/include/synth/synth.h
@@ -27,6 +27,7 @@ enum class TSynth
 {
 	MT32,
 	SoundFont,
+        Passthrough,
 };
 
 #endif

--- a/include/synth/sysex.h
+++ b/include/synth/sysex.h
@@ -47,7 +47,6 @@ enum class TGeneralMIDISubID : u8
 {
 	GeneralMIDIOn  = 0x01,
 	GeneralMIDIOff = 0x02,
-	Passthrough = 0x03,
 };
 
 #endif

--- a/include/synth/sysex.h
+++ b/include/synth/sysex.h
@@ -47,6 +47,7 @@ enum class TGeneralMIDISubID : u8
 {
 	GeneralMIDIOn  = 0x01,
 	GeneralMIDIOff = 0x02,
+	Passthrough = 0x03,
 };
 
 #endif

--- a/patches/fluidsynth-2.2.1-circle.patch
+++ b/patches/fluidsynth-2.2.1-circle.patch
@@ -22,7 +22,7 @@ diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
 index 356bb734..f44fc7f0 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -199,21 +199,21 @@ set ( libfluidsynth_SOURCES
+@@ -203,23 +203,23 @@
      synth/fluid_tuning.h
      synth/fluid_voice.c
      synth/fluid_voice.h
@@ -31,7 +31,9 @@ index 356bb734..f44fc7f0 100644
 -    midi/fluid_midi_router.c
 -    midi/fluid_midi_router.h
 -    midi/fluid_seqbind.c
+-    midi/fluid_seqbind_notes.cpp
 -    midi/fluid_seq.c
+-    midi/fluid_seq_queue.cpp
 -    drivers/fluid_adriver.c
 -    drivers/fluid_adriver.h
 -    drivers/fluid_mdriver.c
@@ -46,7 +48,9 @@ index 356bb734..f44fc7f0 100644
 +    #midi/fluid_midi_router.c
 +    #midi/fluid_midi_router.h
 +    #midi/fluid_seqbind.c
++    #midi/fluid_seqbind_notes.cpp
 +    #midi/fluid_seq.c
++    #midi/fluid_seq_queue.cpp
 +    #drivers/fluid_adriver.c
 +    #drivers/fluid_adriver.h
 +    #drivers/fluid_mdriver.c
@@ -71,7 +75,7 @@ index 140fc3c5..5780367b 100644
  void *default_fopen(const char *path)
  {
      const char* msg;
-@@ -74,6 +75,13 @@ int safe_fseek(void *fd, long ofs, int whence)
+@@ -80,6 +81,13 @@
  
      return FLUID_OK;
  }
@@ -79,12 +83,29 @@ index 140fc3c5..5780367b 100644
 +
 +void *default_fopen(const char *path);
 +int default_fclose(void *handle);
-+long default_ftell(void *handle);
-+int safe_fread(void *buf, int count, void *fd);
-+int safe_fseek(void *fd, long ofs, int whence);
++fluid_long_long_t default_ftell(void *handle);
++int safe_fread(void *buf, fluid_long_long_t count, void *fd);
++int safe_fseek(void *fd, fluid_long_long_t ofs, int whence);
+ 
+ #undef PRIi64
+ 
+@@ -147,7 +155,7 @@
+     loader->data = data;
+     return FLUID_OK;
+ }
+-
++//#endif
+ /**
+  * Obtain private data previously set with fluid_sfloader_set_data().
+  *
+@@ -202,6 +210,7 @@
+     // NOTE: if we ever make the instpatch loader public, this may return FLUID_FAILED
+     return FLUID_OK;
+ }
++//#endif
  
  /**
-  * Creates a new SoundFont loader.
+  * Creates a new virtual SoundFont instance structure.
 diff --git a/src/synth/fluid_synth.c b/src/synth/fluid_synth.c
 index 1e0b29fb..cc3e0cc1 100644
 --- a/src/synth/fluid_synth.c
@@ -201,7 +222,7 @@ index 9da394e7..42abbabf 100644
  typedef struct
  {
      fluid_thread_func_t func;
-@@ -82,6 +83,7 @@ struct _fluid_server_socket_t
+@@ -82,6 +83,7 @@
  
  
  static int fluid_istream_gets(fluid_istream_t in, char *buf, int len);
@@ -209,7 +230,7 @@ index 9da394e7..42abbabf 100644
  
  static fluid_log_function_t fluid_log_function[LAST_LOG_LEVEL] =
  {
-@@ -198,6 +200,7 @@ fluid_log(int level, const char *fmt, ...)
+@@ -198,6 +200,7 @@
      return FLUID_FAILED;
  }
  
@@ -217,7 +238,7 @@ index 9da394e7..42abbabf 100644
  void* fluid_alloc(size_t len)
  {
      void* ptr = malloc(len);
-@@ -231,6 +234,7 @@ void fluid_free(void* ptr)
+@@ -295,6 +298,7 @@
  {
      free(ptr);
  }
@@ -225,7 +246,7 @@ index 9da394e7..42abbabf 100644
  
  /**
   * An improved strtok, still trashes the input string, but is portable and
-@@ -308,6 +312,7 @@ char *fluid_strtok(char **str, char *delim)
+@@ -372,6 +376,7 @@
      return token;
  }
  
@@ -233,7 +254,7 @@ index 9da394e7..42abbabf 100644
  /**
   * Suspend the execution of the current thread for the specified amount of time.
   * @param milliseconds to wait.
-@@ -316,6 +321,7 @@ void fluid_msleep(unsigned int msecs)
+@@ -380,6 +385,7 @@
  {
      g_usleep(msecs * 1000);
  }
@@ -241,7 +262,7 @@ index 9da394e7..42abbabf 100644
  
  /**
   * Get time in milliseconds to be used in relative timing operations.
-@@ -336,6 +342,7 @@ unsigned int fluid_curtime(void)
+@@ -400,6 +406,7 @@
      return (unsigned int)((now - initial_time) / 1000.0f);
  }
  
@@ -249,11 +270,14 @@ index 9da394e7..42abbabf 100644
  /**
   * Get time in microseconds to be used in relative timing operations.
   * @return time in microseconds.
-@@ -1688,3 +1695,4 @@ FILE* fluid_file_open(const char* path, const char** errMsg)
+@@ -1754,6 +1761,7 @@
      
      return handle;
  }
 +#endif
+ 
+ fluid_long_long_t fluid_file_tell(FILE* f)
+ {
 diff --git a/src/utils/fluid_sys.h b/src/utils/fluid_sys.h
 index 7c7db764..f76d943b 100644
 --- a/src/utils/fluid_sys.h

--- a/src/synth/passthroughsynth.cpp
+++ b/src/synth/passthroughsynth.cpp
@@ -1,0 +1,112 @@
+//
+// passthroughsynth.cpp
+//
+// mt32-pi - A baremetal MIDI synthesizer for Raspberry Pi
+// Copyright (C) 2020-2021 Dale Whinham <daleyo@gmail.com>
+//
+// This file is part of mt32-pi.
+//
+// mt32-pi is free software: you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// mt32-pi is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// mt32-pi. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include <fatfs/ff.h>
+#include <circle/logger.h>
+#include <circle/timer.h>
+
+
+#include "config.h"
+#include "synth/gmsysex.h"
+#include "synth/rolandsysex.h"
+#include "synth/passthroughsynth.h"
+#include "utility.h"
+#include "zoneallocator.h"
+
+CPassthroughSynth::CPassthroughSynth(unsigned nSampleRate, float nGain, u32 nPolyphony)
+	: CSynthBase(nSampleRate),
+
+	  m_pSettings(nullptr),
+	  m_pSynth(nullptr),
+
+	  m_nInitialGain(nGain),
+	  m_nCurrentGain(nGain),
+
+	  m_nPolyphony(nPolyphony),
+	  m_nCurrentSoundFontIndex(0)
+{
+}
+
+CPassthroughSynth::~CPassthroughSynth()
+{
+}
+
+void CPassthroughSynth::FluidSynthLogCallback(int nLevel, const char* pMessage, void* pUser)
+{
+}
+
+bool CPassthroughSynth::Initialize()
+{
+    	return 1;
+}
+
+void CPassthroughSynth::HandleMIDIShortMessage(u32 nMessage)
+{
+}
+
+void CPassthroughSynth::HandleMIDISysExMessage(const u8* pData, size_t nSize)
+{
+}
+
+bool CPassthroughSynth::IsActive()
+{
+    	return 1;
+}
+
+void CPassthroughSynth::AllSoundOff()
+{
+}
+
+void CPassthroughSynth::SetMasterVolume(u8 nVolume)
+{
+}
+
+size_t CPassthroughSynth::Render(float* pOutBuffer, size_t nFrames)
+{
+	return nFrames;
+}
+
+size_t CPassthroughSynth::Render(s16* pOutBuffer, size_t nFrames)
+{
+	return nFrames;
+}
+
+u8 CPassthroughSynth::GetChannelVelocities(u8* pOutVelocities, size_t nMaxChannels)
+{
+	return nMaxChannels;
+}
+
+void CPassthroughSynth::ReportStatus() const
+{
+	//if (m_pLCD)
+	//	m_pLCD->OnSystemMessage(m_SoundFontManager.GetSoundFontName(m_nCurrentSoundFontIndex));
+}
+
+bool CPassthroughSynth::SwitchSoundFont(size_t nIndex)
+{
+	return true;
+}
+
+bool CPassthroughSynth::Reinitialize(const char* pSoundFontPath)
+{
+	return true;
+}

--- a/src/synth/passthroughsynth.cpp
+++ b/src/synth/passthroughsynth.cpp
@@ -56,6 +56,8 @@ void CPassthroughSynth::FluidSynthLogCallback(int nLevel, const char* pMessage, 
 
 bool CPassthroughSynth::Initialize()
 {
+//	if (m_pLCD)
+//		m_pLCD->OnSystemMessage("Passthrough Initializing");
     	return 1;
 }
 
@@ -97,8 +99,8 @@ u8 CPassthroughSynth::GetChannelVelocities(u8* pOutVelocities, size_t nMaxChanne
 
 void CPassthroughSynth::ReportStatus() const
 {
-	//if (m_pLCD)
-	//	m_pLCD->OnSystemMessage(m_SoundFontManager.GetSoundFontName(m_nCurrentSoundFontIndex));
+//	if (m_pLCD)
+//		m_pLCD->OnSystemMessage("Passthrough enabled");
 }
 
 bool CPassthroughSynth::SwitchSoundFont(size_t nIndex)

--- a/src/synth/soundfontsynth.cpp
+++ b/src/synth/soundfontsynth.cpp
@@ -92,20 +92,20 @@ extern "C"
 		return FLUID_FAILED;
 	}
 
-	long default_ftell(void* handle)
+	fluid_long_long_t default_ftell(void* handle)
 	{
 		FIL* pFile = static_cast<FIL*>(handle);
 		return f_tell(pFile);
 	}
 
-	int safe_fread(void* buf, int count, void* fd)
+	int safe_fread(void* buf, fluid_long_long_t count, void* fd)
 	{
 		FIL* pFile = static_cast<FIL*>(fd);
 		UINT nRead;
 		return f_read(pFile, buf, count, &nRead) == FR_OK ? FLUID_OK : FLUID_FAILED;
 	}
 
-	int safe_fseek(void* fd, long ofs, int whence)
+	int safe_fseek(void* fd, fluid_long_long_t ofs, int whence)
 	{
 		FIL* pFile = static_cast<FIL*>(fd);
 


### PR DESCRIPTION
Tested sending a third sysex for changing the synth to 'Passthrough Mode', it seems to be working as expected. I am able to switch between passthrough and mt32 and local soundfonts.

I also updated fluidsynth to the current latest repo build.